### PR TITLE
Update rest_client.class.php

### DIFF
--- a/rest_client.class.php
+++ b/rest_client.class.php
@@ -391,7 +391,7 @@ class rest_client
     }
     
     /**
-    * Method to execute execute curl_multi call
+    * Method to execute curl_multi call
     * 
     * @return void
     * @throws Exception


### PR DESCRIPTION
redundant word in the documentation of the method _curl_multi_exec.
